### PR TITLE
Implement basic Janus WebSocket client in Dart

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,92 +1,34 @@
-
 import 'package:janus_flutter/janus.dart';
 
+/// Simple example showing how to connect to a Janus Gateway using this library.
 void main() {
-  // 1. Initialize the Janus library
-  Janus.init(
-    debug: ["log", "error"],
-    callback: () {
-      // Initialization is complete, now we can create a session.
-      createJanusSession();
-    },
-  );
-}
+  Janus.init(callback: () async {
+    final session = JanusSession(
+      server: 'wss://your-janus-server.com/websocket',
+      onSuccess: () {
+        print('Janus session established: ${session.getSessionId()}');
 
-void createJanusSession() {
-  late JanusSession janus;
-  late JanusPluginHandle videoRoomHandle;
-
-  // 2. Create a new Janus session
-  janus = JanusSession(
-    server: 'wss://your-janus-server.com/ws', // Replace with your Janus server URL
-    onSuccess: () {
-      print("Janus session created successfully!");
-
-      // 3. Attach to the VideoRoom plugin
-      janus.attach(
-        plugin: "janus.plugin.videoroom",
-        success: (handle) {
-          videoRoomHandle = handle;
-          print("Attached to VideoRoom plugin! Handle ID: ${videoRoomHandle.getId()}");
-
-          // 4. Join a room
-          // This is a plugin-specific message.
-          final joinMessage = {
-            "request": "join",
-            "room": 1234, // Example room number
-            "ptype": "publisher",
-            "display": "Dart User"
-          };
-
-          videoRoomHandle.send(
-              message: joinMessage,
-              success: (data) {
-                print("Join request sent successfully.");
-              },
-              error: (error) {
-                print("Error sending join request: $error");
-              }
-          );
-        },
-        error: (error) {
-          print("Failed to attach to VideoRoom plugin: $error");
-        },
-        onmessage: (msg, jsep) {
-          // 5. Handle asynchronous events from the plugin
-          print("Got a message from the plugin:");
-          print(msg);
-
-          final event = msg['videoroom'];
-          if (event == 'joined') {
-            print("Successfully joined room ${msg['room']}!");
-            // At this point, you would typically create an offer to start publishing.
-            // videoRoomHandle.createOffer(...);
-          } else if (event == 'event') {
-            // Handle other events, like new publishers joining the room.
-            if (msg['publishers'] != null) {
-              print("New publishers in the room: ${msg['publishers']}");
-              // For each publisher, you would create a new subscriber handle
-              // and send a "join" request with ptype: "subscriber".
+        session.attach(
+          plugin: 'janus.plugin.echotest',
+          success: (handle) {
+            print('Plugin attached with handle: ${handle.getId()}');
+            handle.send(
+              message: {'echo': 'Hello from Dart'},
+              success: (_) => print('Message sent'),
+              error: (e) => print('Failed to send message: $e'),
+            );
+          },
+          error: (e) => print('Attach failed: $e'),
+          onmessage: (msg, jsep) {
+            print('Received message: $msg');
+            if (jsep != null) {
+              print('Received JSEP: ${jsep.toMap()}');
             }
-          }
-
-          if (jsep != null) {
-            print("Got a JSEP offer/answer:");
-            print(jsep.toMap());
-            // Handle the JSEP, e.g., by creating an answer.
-            // videoRoomHandle.createAnswer(jsep: jsep, ...);
-          }
-        },
-        oncleanup: () {
-          print("Plugin handle cleaned up.");
-        },
-      );
-    },
-    onError: (error) {
-      print("Failed to create Janus session: $error");
-    },
-    onDestroyed: () {
-      print("Janus session destroyed.");
-    },
-  );
+          },
+        );
+      },
+      onError: (e) => print('Session error: $e'),
+      onDestroyed: () => print('Session destroyed'),
+    );
+  });
 }

--- a/lib/src/websocket_client.dart
+++ b/lib/src/websocket_client.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Simple wrapper around [WebSocketChannel] that exposes callbacks for incoming
+/// data, errors and connection close events.
+class JanusWebSocketClient {
+  JanusWebSocketClient({
+    required this.url,
+    this.onData,
+    this.onError,
+    this.onDone,
+  });
+
+  final String url;
+  final void Function(dynamic data)? onData;
+  final void Function(Object error)? onError;
+  final void Function()? onDone;
+
+  WebSocketChannel? _channel;
+
+  Future<void> connect() async {
+    _channel = WebSocketChannel.connect(Uri.parse(url));
+    _channel!.stream.listen(onData, onError: onError, onDone: onDone);
+  }
+
+  bool get isConnected => _channel != null;
+
+  void send(dynamic data) {
+    _channel?.sink.add(data);
+  }
+
+  Future<void> close() async {
+    await _channel?.sink.close();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   flutter_webrtc: ^0.14.2
+  web_socket_channel: ^2.4.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- implement a simple WebSocket client wrapper
- flesh out JanusSession to open a WebSocket, create sessions and attach plugins
- add ability for plugin handle to send messages and detach
- add minimal example showing connection and message exchange
- add web_socket_channel dependency

## Testing
- `dart format -o none --set-exit-if-changed lib example` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_686537b8ef748324a0628d9bb250df05