### PR TITLE
Implement WebRTC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # janus_flutter
 
-A new Flutter project.
+A Flutter plugin providing a client for the [Janus WebRTC Server](https://janus.conf.meetecho.com/).
+It allows establishing WebRTC sessions and exchanging media streams directly from
+Flutter applications.
 
 ## Getting Started
 
-This project is a starting point for a Flutter
-[plug-in package](https://flutter.dev/to/develop-plugins),
-a specialized package that includes platform-specific implementation code for
-Android and/or iOS.
+The plugin exposes the Janus session API and now includes helpers to manage
+`RTCPeerConnection` instances. It takes care of handling ICE candidates,
+SDP offer/answer negotiation and basic WebRTC events.
+
+See `example/lib/main.dart` for a full example that connects to the Janus
+`echotest` plugin and streams audio/video using `flutter_webrtc`.
 
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev), which offers tutorials,

--- a/lib/janus.dart
+++ b/lib/janus.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
 import 'log/janus_log.dart';
 
 
@@ -68,6 +70,10 @@ typedef WebRTCStateCallback = void Function(bool on, String? reason);
 typedef SlowLinkCallback = void Function(bool uplink, int lost, String? mid);
 typedef OnCleanupCallback = void Function();
 typedef OnDetachedCallback = void Function();
+typedef OnLocalStreamCallback = void Function(MediaStream stream);
+typedef OnRemoteStreamCallback = void Function(MediaStream stream);
+typedef OnIceCandidateCallback = void Function(RTCIceCandidate candidate);
+typedef PeerConnectionStateCallback = void Function(RTCPeerConnectionState state);
 
 // --- Main Janus Class ---
 class Janus {
@@ -415,6 +421,9 @@ class JanusSession {
       case 'slowlink':
         _handleSlowLink(json);
         break;
+      case 'trickle':
+        _handleTrickle(json);
+        break;
       case 'error':
         JanusLogger.error('Server error: ${json['error']}');
         break;
@@ -493,6 +502,15 @@ class JanusSession {
     }
   }
 
+  void _handleTrickle(Map<String, dynamic> json) {
+    final sender = json['sender'] as int?;
+    if (sender == null) return;
+
+    final pluginHandle = _pluginHandles[sender];
+    final candidate = json['candidate'] as Map<String, dynamic>?;
+    pluginHandle?._handleRemoteCandidate(candidate);
+  }
+
   Future<Map<String, dynamic>> _sendMessage(Map<String, dynamic> message, String transaction) async {
     if (_webSocket == null) {
       throw Exception('WebSocket not connected');
@@ -564,8 +582,18 @@ class JanusPluginHandle {
   final SlowLinkCallback? slowLink;
   final OnCleanupCallback? oncleanup;
   final OnDetachedCallback? ondetached;
+  final OnLocalStreamCallback? onLocalStream;
+  final OnRemoteStreamCallback? onRemoteStream;
+  final OnIceCandidateCallback? onLocalCandidate;
+  final PeerConnectionStateCallback? onPeerConnectionState;
 
   bool _detached = false;
+
+  RTCPeerConnection? _peerConnection;
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
+  final List<RTCIceCandidate> _remoteCandidates = [];
+  bool _remoteDescriptionSet = false;
 
   JanusPluginHandle({
     required this.session,
@@ -579,12 +607,117 @@ class JanusPluginHandle {
     this.slowLink,
     this.oncleanup,
     this.ondetached,
+    this.onLocalStream,
+    this.onRemoteStream,
+    this.onLocalCandidate,
+    this.onPeerConnectionState,
   });
 
   // --- Public API ---
   int getId() => id;
   String getPlugin() => plugin;
   bool isDetached() => _detached;
+
+  Future<void> initPeerConnection({
+    required Map<String, dynamic> configuration,
+    MediaStream? stream,
+  }) async {
+    _peerConnection = await createPeerConnection(configuration);
+    _localStream = stream;
+    if (stream != null) {
+      onLocalStream?.call(stream);
+      for (final track in stream.getTracks()) {
+        await _peerConnection!.addTrack(track, stream);
+      }
+    }
+
+    _peerConnection!.onIceCandidate = (candidate) {
+      if (candidate == null) {
+        trickleComplete();
+        return;
+      }
+      onLocalCandidate?.call(candidate);
+      _trickleCandidate(candidate);
+    };
+
+    _peerConnection!.onTrack = (event) {
+      if (event.streams.isNotEmpty) {
+        _remoteStream = event.streams[0];
+        onRemoteStream?.call(_remoteStream!);
+      }
+    };
+
+    _peerConnection!.onConnectionState = (state) {
+      onPeerConnectionState?.call(state);
+    };
+  }
+
+  Future<Jsep> createOffer([Map<String, dynamic> constraints = const {}]) async {
+    final description = await _peerConnection!.createOffer(constraints);
+    await _peerConnection!.setLocalDescription(description);
+    return Jsep(type: description.type, sdp: description.sdp!);
+  }
+
+  Future<Jsep> createAnswer([Map<String, dynamic> constraints = const {}]) async {
+    final description = await _peerConnection!.createAnswer(constraints);
+    await _peerConnection!.setLocalDescription(description);
+    return Jsep(type: description.type, sdp: description.sdp!);
+  }
+
+  Future<void> handleRemoteJsep(Jsep jsep) async {
+    final desc = RTCSessionDescription(jsep.sdp, jsep.type);
+    await _peerConnection!.setRemoteDescription(desc);
+    _remoteDescriptionSet = true;
+    for (final cand in _remoteCandidates) {
+      await _peerConnection!.addCandidate(cand);
+    }
+    _remoteCandidates.clear();
+  }
+
+  Future<void> trickleComplete() async {
+    final request = {
+      'janus': 'trickle',
+      'candidate': {'completed': true},
+      'session_id': session.getSessionId(),
+      'handle_id': id,
+      'transaction': Janus.randomString(12),
+    };
+
+    await session._sendMessage(request, request['transaction'] as String);
+  }
+
+  Future<void> _trickleCandidate(RTCIceCandidate candidate) async {
+    final request = {
+      'janus': 'trickle',
+      'candidate': {
+        'candidate': candidate.candidate,
+        'sdpMid': candidate.sdpMid,
+        'sdpMLineIndex': candidate.sdpMlineIndex,
+      },
+      'session_id': session.getSessionId(),
+      'handle_id': id,
+      'transaction': Janus.randomString(12),
+    };
+
+    await session._sendMessage(request, request['transaction'] as String);
+  }
+
+  Future<void> _handleRemoteCandidate(Map<String, dynamic>? cand) async {
+    if (cand == null) return;
+    if (cand['completed'] == true) {
+      return;
+    }
+    final candidate = RTCIceCandidate(
+      cand['candidate'] as String?,
+      cand['sdpMid'] as String?,
+      cand['sdpMLineIndex'] as int?,
+    );
+    if (_remoteDescriptionSet) {
+      await _peerConnection?.addCandidate(candidate);
+    } else {
+      _remoteCandidates.add(candidate);
+    }
+  }
 
   /// Send a message to the plugin
   Future<void> send({
@@ -665,6 +798,10 @@ class JanusPluginHandle {
 
   Future<void> _cleanup() async {
     _detached = true;
+    await _peerConnection?.close();
+    _peerConnection = null;
+    _localStream = null;
+    _remoteStream = null;
     session._pluginHandles.remove(id);
     oncleanup?.call();
   }


### PR DESCRIPTION
## Summary
- integrate flutter_webrtc in plugin implementation
- add peer connection helpers and ICE handling
- update cleanup routines
- expand example to show WebRTC media exchange
- document new WebRTC features

## Testing
- `dart format lib/janus.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653f9fe2dc83248f81acb2d0282d04