### PR TITLE
Add WebRTC support for Janus plugin

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,92 +1,60 @@
-
+import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:janus_flutter/janus.dart';
 
-void main() {
-  // 1. Initialize the Janus library
+Future<void> main() async {
   Janus.init(
-    debug: ["log", "error"],
+    debug: ['log', 'error', 'debug'],
     callback: () {
-      // Initialization is complete, now we can create a session.
       createJanusSession();
     },
   );
 }
 
 void createJanusSession() {
-  late JanusSession janus;
-  late JanusPluginHandle videoRoomHandle;
+  late JanusSession session;
+  late JanusPluginHandle echoHandle;
+  MediaStream? localStream;
 
-  // 2. Create a new Janus session
-  janus = JanusSession(
-    server: 'wss://your-janus-server.com/ws', // Replace with your Janus server URL
+  session = JanusSession(
+    server: 'wss://your-janus-server.com/ws',
     onSuccess: () {
-      print("Janus session created successfully!");
+      session.attach(
+        plugin: 'janus.plugin.echotest',
+        success: (handle) async {
+          echoHandle = handle;
 
-      // 3. Attach to the VideoRoom plugin
-      janus.attach(
-        plugin: "janus.plugin.videoroom",
-        success: (handle) {
-          videoRoomHandle = handle;
-          print("Attached to VideoRoom plugin! Handle ID: ${videoRoomHandle.getId()}");
+          localStream = await navigator.mediaDevices.getUserMedia({
+            'audio': true,
+            'video': true,
+          });
 
-          // 4. Join a room
-          // This is a plugin-specific message.
-          final joinMessage = {
-            "request": "join",
-            "room": 1234, // Example room number
-            "ptype": "publisher",
-            "display": "Dart User"
-          };
+          await echoHandle.createPeerConnection(
+            mediaStreams: [localStream!],
+            onLocalCandidate: (c) => print('Local candidate: ${c.candidate}'),
+            onConnectionState: (state) => print('Connection state: $state'),
+            onRemoteStream: (stream) {
+              print('Remote stream: ${stream.id}');
+            },
+          );
 
-          videoRoomHandle.send(
-              message: joinMessage,
-              success: (data) {
-                print("Join request sent successfully.");
-              },
-              error: (error) {
-                print("Error sending join request: $error");
-              }
+          final offer = await echoHandle.createOffer();
+          await echoHandle.send(
+            message: {'audio': true, 'video': true},
+            jsep: offer,
+            success: (_) => print('Offer sent'),
+            error: (e) => print('Error sending offer: $e'),
           );
         },
-        error: (error) {
-          print("Failed to attach to VideoRoom plugin: $error");
-        },
-        onmessage: (msg, jsep) {
-          // 5. Handle asynchronous events from the plugin
-          print("Got a message from the plugin:");
-          print(msg);
-
-          final event = msg['videoroom'];
-          if (event == 'joined') {
-            print("Successfully joined room ${msg['room']}!");
-            // At this point, you would typically create an offer to start publishing.
-            // videoRoomHandle.createOffer(...);
-          } else if (event == 'event') {
-            // Handle other events, like new publishers joining the room.
-            if (msg['publishers'] != null) {
-              print("New publishers in the room: ${msg['publishers']}");
-              // For each publisher, you would create a new subscriber handle
-              // and send a "join" request with ptype: "subscriber".
-            }
-          }
-
+        error: (err) => print('Attach error: $err'),
+        onmessage: (msg, jsep) async {
+          print('Plugin message: $msg');
           if (jsep != null) {
-            print("Got a JSEP offer/answer:");
-            print(jsep.toMap());
-            // Handle the JSEP, e.g., by creating an answer.
-            // videoRoomHandle.createAnswer(jsep: jsep, ...);
+            await echoHandle.handleRemoteJsep(jsep);
           }
-        },
-        oncleanup: () {
-          print("Plugin handle cleaned up.");
         },
       );
     },
-    onError: (error) {
-      print("Failed to create Janus session: $error");
-    },
-    onDestroyed: () {
-      print("Janus session destroyed.");
-    },
+    onError: (error) => print('Session error: $error'),
+    onDestroyed: () => print('Session destroyed'),
   );
 }


### PR DESCRIPTION
## Summary
- add WebRTC integration to Janus plugin
- implement ICE candidate handling and SDP operations
- handle server trickle events
- provide WebRTC example using the echotest plugin

## Testing
- `dart format -o none --set-exit-if-changed lib example` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653fa78e2483249d12c53610c81e67