### PR TITLE
Add Janus echo test example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,17 @@
 # janus_flutter_example
 
-Demonstrates how to use the janus_flutter plugin.
+This example demonstrates how to connect to a Janus WebRTC server and run the
+`janus.plugin.echotest` plugin. Two video windows will appear showing the local
+and remote streams.
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
+### Running the example
 
-A few resources to get you started if this is your first Flutter project:
+1. Install Flutter on your machine.
+2. From the repository root run `flutter pub get` inside the `example` folder.
+3. Start the example with `flutter run`.
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+The example uses the public Janus demo server at
+`wss://janus.conf.meetecho.com/ws`. You can change the server URL in
+`example/lib/main.dart` if you are running your own Janus instance.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,60 +1,137 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:janus_flutter/janus.dart';
 
 Future<void> main() async {
-  Janus.init(
-    debug: ['log', 'error', 'debug'],
-    callback: () {
-      createJanusSession();
-    },
-  );
+  WidgetsFlutterBinding.ensureInitialized();
+  await Janus.init(debug: ['log', 'error', 'debug']);
+  runApp(const JanusExampleApp());
 }
 
-void createJanusSession() {
-  late JanusSession session;
-  late JanusPluginHandle echoHandle;
-  MediaStream? localStream;
+class JanusExampleApp extends StatefulWidget {
+  const JanusExampleApp({super.key});
 
-  session = JanusSession(
-    server: 'wss://your-janus-server.com/ws',
-    onSuccess: () {
-      session.attach(
-        plugin: 'janus.plugin.echotest',
-        success: (handle) async {
-          echoHandle = handle;
+  @override
+  State<JanusExampleApp> createState() => _JanusExampleAppState();
+}
 
-          localStream = await navigator.mediaDevices.getUserMedia({
-            'audio': true,
-            'video': true,
-          });
+class _JanusExampleAppState extends State<JanusExampleApp> {
+  JanusSession? _session;
+  JanusPluginHandle? _echoHandle;
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
 
-          await echoHandle.initPeerConnection(
-            mediaStreams: [localStream!],
-            onLocalCandidate: (c) => print('Local candidate: ${c.candidate}'),
-            onConnectionState: (state) => print('Connection state: $state'),
-            onRemoteStream: (stream) {
-              print('Remote stream: ${stream.id}');
-            },
-          );
+  final RTCVideoRenderer _localRenderer = RTCVideoRenderer();
+  final RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
 
-          final offer = await echoHandle.createOffer();
-          await echoHandle.send(
-            message: {'audio': true, 'video': true},
-            jsep: offer,
-            success: (_) => print('Offer sent'),
-            error: (e) => print('Error sending offer: $e'),
-          );
-        },
-        error: (err) => print('Attach error: $err'),
-        onmessage: (msg, jsep) async {
-          print('Plugin message: $msg');
-          if (jsep != null) {
-            await echoHandle.handleRemoteJsep(jsep);
-          }
-        },
-      );
-    },
-    onError: (error) => print('Session error: $error'),
-    onDestroyed: () => print('Session destroyed'),
-  );
+  bool _connecting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _localRenderer.initialize();
+    _remoteRenderer.initialize();
+  }
+
+  @override
+  void dispose() {
+    _localRenderer.dispose();
+    _remoteRenderer.dispose();
+    _localStream?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _startEchoTest() async {
+    setState(() => _connecting = true);
+
+    _session = JanusSession(
+      server: 'wss://janus.conf.meetecho.com/ws',
+      onSuccess: () {
+        _session!.attach(
+          plugin: 'janus.plugin.echotest',
+          success: (handle) async {
+            _echoHandle = handle;
+
+            _localStream = await navigator.mediaDevices.getUserMedia({
+              'audio': true,
+              'video': true,
+            });
+            _localRenderer.srcObject = _localStream;
+
+            await _echoHandle!.initPeerConnection(
+              mediaStreams: [_localStream!],
+              onRemoteStream: (stream) {
+                setState(() {
+                  _remoteStream = stream;
+                  _remoteRenderer.srcObject = _remoteStream;
+                });
+              },
+            );
+
+            final offer = await _echoHandle!.createOffer();
+            await _echoHandle!.send(
+              message: {'audio': true, 'video': true},
+              jsep: offer,
+            );
+
+            setState(() {});
+          },
+          error: (err) {
+            debugPrint('Attach error: $err');
+            setState(() => _connecting = false);
+          },
+          onmessage: (msg, jsep) async {
+            if (jsep != null) {
+              await _echoHandle!.handleRemoteJsep(jsep);
+            }
+          },
+        );
+      },
+      onError: (error) {
+        debugPrint('Session error: $error');
+        setState(() => _connecting = false);
+      },
+      onDestroyed: () {
+        setState(() {
+          _connecting = false;
+          _session = null;
+          _echoHandle = null;
+          _localRenderer.srcObject = null;
+          _remoteRenderer.srcObject = null;
+          _localStream?.dispose();
+          _localStream = null;
+          _remoteStream = null;
+        });
+      },
+    );
+  }
+
+  Future<void> _stop() async {
+    await _echoHandle?.closePeerConnection();
+    await _session?.destroy();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Janus Echo Test')),
+        body: Column(
+          children: [
+            Expanded(child: RTCVideoView(_localRenderer, mirror: true)),
+            Expanded(child: RTCVideoView(_remoteRenderer)),
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: _connecting
+                  ? ElevatedButton(onPressed: _stop, child: const Text('Stop'))
+                  : ElevatedButton(
+                      onPressed: _startEchoTest,
+                      child: const Text('Start Echo Test'),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- build a small example app that connects to the Janus demo server
- explain how to run the example in README

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686563a68d308324b8831c1b2b845d6d